### PR TITLE
Add shebang to make the script directly runable

### DIFF
--- a/pig.py
+++ b/pig.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import random
 from PySide.QtCore import *


### PR DESCRIPTION
Can now run `./pig.py` instead of `python3 ./pig.py`
